### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   check:
     name: Lint & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mikkovihonen/pi-container/security/code-scanning/1](https://github.com/mikkovihonen/pi-container/security/code-scanning/1)

Add an explicit `permissions` block for the `check` job with least privilege.  
Best fix here (without changing behavior): set `contents: read` under `jobs.check`, since this job only needs to read repository contents for checkout and lint/test tasks. Keep the existing `test` job permissions unchanged (`contents: write`) because it commits and pushes the coverage badge.

Edit only `.github/workflows/ci.yml`, in the `check` job section just below `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
